### PR TITLE
Get delta

### DIFF
--- a/client/python/anna/base_client.py
+++ b/client/python/anna/base_client.py
@@ -233,6 +233,31 @@ class BaseAnnaClient():
 
         return (req, tuples)
 
+    # Helper function to create a KeyRequest (see
+    # hydro-project/common/proto/anna.proto). Takes in a key name and returns a
+    # tuple containing a KeyRequest and a KeyTuple contained in that KeyRequest
+    # with response_address, request_id, and address_cache_size automatically
+    # populated.
+    def _prepare_delta_data_request(self, keys, serialized_previous):
+        req = KeyRequest()
+        req.request_id = self._get_request_id()
+        req.response_address = self.response_address
+
+        tuples = []
+
+        for key in keys:
+            # TODO: is tup included in req?
+            tup = req.tuples.add()
+            tuples.append(tup)
+            tup.key = key
+            tup.previous_payload = serialized_previous
+
+            if self.address_cache and key in self.address_cache:
+                tup.address_cache_size = len(self.address_cache[key])
+
+        return (req, tuples)
+
+
     # Returns and increments a request ID. Loops back after 10,000 requests.
     def _get_request_id(self):
         response = self.ut.get_ip() + ':' + str(self.rid)

--- a/client/python/anna/base_client.py
+++ b/client/python/anna/base_client.py
@@ -251,6 +251,7 @@ class BaseAnnaClient():
             tuples.append(tup)
             tup.key = key
             tup.previous_payload = serialized_previous
+            tup.delta = True
 
             if self.address_cache and key in self.address_cache:
                 tup.address_cache_size = len(self.address_cache[key])

--- a/client/python/anna/client.py
+++ b/client/python/anna/client.py
@@ -178,17 +178,12 @@ class AnnaTcpClient(BaseAnnaClient):
 
                     lattice_value = self._deserialize(tup)
 
-                    if (lattice_value.payload == "ACK"):
+                    if (lattice_value.identical):
                         lattice_value = self.cache[key]
 
                     if tup.error == NO_ERROR:
                         kv_pairs[tup.key] = lattice_value
                         cache[tup.key] = lattice_value
-
-                    # if tup.lattice_type == LWW:
-                    #     cache[tup.key] = LWWPairLattice(tup.timestamp, "")
-                    # if tup.lattice_type == SET:
-                    #     cache[tup.key] = SetLattice(tup.payload)
 
             return kv_pairs
 

--- a/client/python/anna/client.py
+++ b/client/python/anna/client.py
@@ -177,6 +177,10 @@ class AnnaTcpClient(BaseAnnaClient):
                         self._invalidate_cache(tup.key)
 
                     lattice_value = self._deserialize(tup)
+
+                    if (lattice_value.payload == "ACK"):
+                        lattice_value = self.cache[key]
+
                     if tup.error == NO_ERROR:
                         kv_pairs[tup.key] = lattice_value
                         cache[tup.key] = lattice_value

--- a/include/kvs/kvs_handlers.hpp
+++ b/include/kvs/kvs_handlers.hpp
@@ -92,7 +92,7 @@ void send_gossip(AddressKeysetMap &addr_keyset_map, SocketCache &pushers,
                  map<Key, KeyProperty> &stored_key_map);
 
 std::pair<string, AnnaError> process_get(const Key &key,
-                                         Serializer *serializer);
+                                         Serializer *serializer, bool delta = false, const string& previous_payload = "");
 
 void process_put(const Key &key, LatticeType lattice_type,
                  const string &payload, Serializer *serializer,

--- a/include/kvs/server_utils.hpp
+++ b/include/kvs/server_utils.hpp
@@ -105,7 +105,7 @@ public:
     if (!delta) {
       return serialize(val);
     } else {
-      if (val.value.reveal() != previous_payload) {
+      if (val.reveal().value != previous_payload) {
         return serialize(val);
       } else {
         return "ACK";

--- a/include/kvs/server_utils.hpp
+++ b/include/kvs/server_utils.hpp
@@ -105,7 +105,8 @@ public:
     if (!delta) {
       return serialize(val);
     } else {
-      if (val.reveal().value != previous_payload) {
+      SetLattice<string> deserialized_payload = deserialize_set(previous_payload);
+      if (val.reveal().value operator!= previous_payload.reveal()) {
         return serialize(val);
       } else {
         return "ACK";

--- a/src/kvs/user_request_handler.cpp
+++ b/src/kvs/user_request_handler.cpp
@@ -39,6 +39,8 @@ void user_request_handler(
     // first check if the thread is responsible for the key
     Key key = tuple.key();
     string payload = tuple.payload();
+    bool delta = tuple.delta();
+    bytes previous_payload = tuple.previous_payload();
 
     ServerThreadList threads = kHashRingUtil->get_responsible_threads(
         wt.replication_response_connect_address(), key, is_metadata(key),
@@ -76,10 +78,11 @@ void user_request_handler(
 
             tp->set_error(AnnaError::KEY_DNE);
           } else {
-            auto res = process_get(key, serializers[stored_key_map[key].type_]);
+            auto res = process_get(key, serializers[stored_key_map[key].type_], delta, previous_payload);
             tp->set_lattice_type(stored_key_map[key].type_);
             tp->set_payload(res.first);
             tp->set_error(res.second);
+            // TODO: do I need to set anything else here?
           }
         } else if (request_type == RequestType::PUT) {
           if (tuple.lattice_type() == LatticeType::NONE) {

--- a/src/kvs/user_request_handler.cpp
+++ b/src/kvs/user_request_handler.cpp
@@ -82,7 +82,6 @@ void user_request_handler(
             tp->set_lattice_type(stored_key_map[key].type_);
             tp->set_payload(res.first);
             tp->set_error(res.second);
-            // TODO: do I need to set anything else here?
           }
         } else if (request_type == RequestType::PUT) {
           if (tuple.lattice_type() == LatticeType::NONE) {

--- a/src/kvs/utils.cpp
+++ b/src/kvs/utils.cpp
@@ -34,6 +34,8 @@ void send_gossip(AddressKeysetMap &addr_keyset_map, SocketCache &pushers,
         type = stored_key_map[key].type_;
       }
 
+
+
       auto res = process_get(key, serializers[type]);
 
       if (res.second == 0) {

--- a/src/kvs/utils.cpp
+++ b/src/kvs/utils.cpp
@@ -51,9 +51,9 @@ void send_gossip(AddressKeysetMap &addr_keyset_map, SocketCache &pushers,
 }
 
 std::pair<string, AnnaError> process_get(const Key &key,
-                                         Serializer *serializer) {
+                                         Serializer *serializer, bool delta, const string &previous_payload) {
   AnnaError error = AnnaError::NO_ERROR;
-  auto res = serializer->get(key, error);
+  auto res = serializer->get(key, error, delta, previous_payload);
   return std::pair<string, AnnaError>(std::move(res), error);
 }
 

--- a/tests/kvs/server_handler_base.hpp
+++ b/tests/kvs/server_handler_base.hpp
@@ -124,6 +124,23 @@ public:
     return request_str;
   }
 
+    string get_key_request_delta(Key key, string ip, string previous_payload) {
+    KeyRequest request;
+    request.set_type(RequestType::GET);
+    request.set_response_address(UserThread(ip, 0).response_connect_address());
+    request.set_request_id(kRequestId);
+
+    KeyTuple *tp = request.add_tuples();
+    tp->set_key(std::move(key));
+    tp->set_delta(true);
+    tp->set_previous_payload(previous_payload);
+
+    string request_str;
+    request.SerializeToString(&request_str);
+
+    return request_str;
+  }
+
   string put_key_request(Key key, LatticeType lattice_type, string payload,
                          string ip) {
     KeyRequest request;

--- a/tests/kvs/test_user_request_handler.hpp
+++ b/tests/kvs/test_user_request_handler.hpp
@@ -52,6 +52,44 @@ TEST_F(ServerHandlerTest, UserGetLWWTest) {
   EXPECT_EQ(key_access_tracker[key].size(), 1);
 }
 
+TEST_F(ServerHandlerTest, UserGetDeltaLWWTest) {
+  Key key = "key";
+  string value = "value";
+  serializers[LatticeType::LWW]->put(key, serialize(0, value));
+  stored_key_map[key].type_ = LatticeType::LWW;
+
+  string get_request = get_key_request_delta(key, ip, value);
+
+  unsigned access_count = 0;
+  unsigned seed = 0;
+
+  EXPECT_EQ(local_changeset.size(), 0);
+
+  user_request_handler(access_count, seed, get_request, log_, global_hash_rings,
+                       local_hash_rings, pending_requests, key_access_tracker,
+                       stored_key_map, key_replication_map, local_changeset, wt,
+                       serializers, pushers);
+
+  vector<string> messages = get_zmq_messages();
+  EXPECT_EQ(messages.size(), 1);
+
+  KeyResponse response;
+  response.ParseFromString(messages[0]);
+
+  EXPECT_EQ(response.response_id(), kRequestId);
+  EXPECT_EQ(response.tuples().size(), 1);
+
+  KeyTuple rtp = response.tuples(0);
+
+  EXPECT_EQ(rtp.key(), key);
+  EXPECT_EQ(rtp.identical(), true);
+  EXPECT_EQ(rtp.error(), 0);
+
+  EXPECT_EQ(local_changeset.size(), 0);
+  EXPECT_EQ(access_count, 1);
+  EXPECT_EQ(key_access_tracker[key].size(), 1);
+}
+
 TEST_F(ServerHandlerTest, UserGetSetTest) {
   Key key = "key";
   set<string> s;


### PR DESCRIPTION
Finish get_delta API on the client-side and server-side. get_delta will cache the queries from user. For repeated queries, the client will send the previous value to the server and the server will respond only "ACK" if the value associated with the queried key has not changed.