### PR TITLE
Asynchronously querying the management node

### DIFF
--- a/dockerfiles/start-anna.sh
+++ b/dockerfiles/start-anna.sh
@@ -58,7 +58,10 @@ if [[ -z "$REPO_BRANCH" ]]; then
 fi
 
 git remote add origin https://github.com/$REPO_ORG/anna
-git fetch -p origin
+while ! (git fetch -p origin)
+do
+  echo "git fetch failed, retrying"
+done
 git checkout -b brnch origin/$REPO_BRANCH
 
 # Compile the latest version of the code on the branch we just check out.

--- a/include/kvs/kvs_handlers.hpp
+++ b/include/kvs/kvs_handlers.hpp
@@ -87,6 +87,15 @@ void cache_ip_response_handler(string &serialized,
                                map<Address, set<Key>> &cache_ip_to_keys,
                                map<Key, set<Address>> &key_to_cache_ips);
 
+void management_node_response_handler(string &serialized,
+                                      set<Address> &extant_caches,
+                                      map<Address, set<Key>> &cache_ip_to_keys,
+                                      map<Key, set<Address>> &key_to_cache_ips,
+                                      GlobalRingMap &global_hash_rings,
+                                      LocalRingMap &local_hash_rings,
+                                      SocketCache &pushers, ServerThread &wt,
+                                      unsigned &rid);
+
 void send_gossip(AddressKeysetMap &addr_keyset_map, SocketCache &pushers,
                  SerializerMap &serializers,
                  map<Key, KeyProperty> &stored_key_map);

--- a/include/kvs_threads.hpp
+++ b/include/kvs_threads.hpp
@@ -41,9 +41,13 @@ const unsigned kGossipPort = 6250;
 // the monitoring system.
 const unsigned kServerReplicationChangePort = 6300;
 
-// The port on which KVS servers listen for responses to a request for the list
-// of all existing caches.
+// The port on which KVS servers listen for responses to a request for listing
+// the keys cached at a function node.
 const unsigned kCacheIpResponsePort = 7050;
+
+// The port on which KVS servers listen for responses from management node to a
+// request for the list of all existing function nodes.
+const unsigned kManagementNodeResponsePort = 7100;
 
 // The port on which routing servers listen for cluster membership requests.
 const unsigned kSeedPort = 6350;
@@ -171,6 +175,14 @@ public:
 
   Address cache_ip_response_bind_address() const {
     return kBindBase + std::to_string(tid_ + kCacheIpResponsePort);
+  }
+
+  Address management_node_response_connect_address() const {
+    return private_base_ + std::to_string(tid_ + kManagementNodeResponsePort);
+  }
+
+  Address management_node_response_bind_address() const {
+    return kBindBase + std::to_string(tid_ + kManagementNodeResponsePort);
   }
 
   Address gossip_connect_address() const {

--- a/src/kvs/CMakeLists.txt
+++ b/src/kvs/CMakeLists.txt
@@ -24,6 +24,7 @@ SET(KVS_SOURCE
   replication_response_handler.cpp
   replication_change_handler.cpp
   cache_ip_response_handler.cpp
+  management_node_response_handler.cpp
   utils.cpp)
 
 ADD_EXECUTABLE(anna-kvs ${KVS_SOURCE})

--- a/src/kvs/management_node_response_handler.cpp
+++ b/src/kvs/management_node_response_handler.cpp
@@ -1,0 +1,62 @@
+//  Copyright 2019 U.C. Berkeley RISE Lab
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "kvs/kvs_handlers.hpp"
+
+void management_node_response_handler(string &serialized,
+                                      set<Address> &extant_caches,
+                                      map<Address, set<Key>> &cache_ip_to_keys,
+                                      map<Key, set<Address>> &key_to_cache_ips,
+                                      GlobalRingMap &global_hash_rings,
+                                      LocalRingMap &local_hash_rings,
+                                      SocketCache &pushers, ServerThread &wt,
+                                      unsigned &rid) {
+  // Get the response.
+  StringSet func_nodes;
+  func_nodes.ParseFromString(serialized);
+
+  // Update extant_caches with the response.
+  set<Address> deleted_caches = std::move(extant_caches);
+  extant_caches = set<Address>();
+  for (const auto &func_node : func_nodes.keys()) {
+    deleted_caches.erase(func_node);
+    extant_caches.insert(func_node);
+  }
+
+  // Process deleted caches
+  // (cache IPs that we were tracking but were not in the newest list of
+  // caches).
+  for (const auto &cache_ip : deleted_caches) {
+    cache_ip_to_keys.erase(cache_ip);
+    for (auto &key_and_caches : key_to_cache_ips) {
+      key_and_caches.second.erase(cache_ip);
+    }
+  }
+
+  // Get the cached keys by cache IP.
+  // First, prepare the requests for all the IPs we know about
+  // and put them in an address request map.
+  map<Address, KeyRequest> addr_request_map;
+  for (const auto &cacheip : extant_caches) {
+    Key key = get_user_metadata_key(cacheip, UserMetadataType::cache_ip);
+    prepare_metadata_get_request(
+        key, global_hash_rings[Tier::MEMORY], local_hash_rings[Tier::MEMORY],
+        addr_request_map, wt.cache_ip_response_connect_address(), rid);
+  }
+
+  // Loop over the address request map and execute all the requests.
+  for (const auto &addr_request : addr_request_map) {
+    send_request<KeyRequest>(addr_request.second, pushers[addr_request.first]);
+  }
+}


### PR DESCRIPTION
1. Changed the management node querying process to be asynchronous (non-blocking). This is because when nodes are added to the cluster, the management node takes a long time to query kubernetes to get node membership. So if the KVS queries the management node synchronously, it will hang for a long time blocking other user requests.

2. Added check in case git fetch fails in the start script.