### PR TITLE
Udpates start script for Ubuntu 18

### DIFF
--- a/dockerfiles/start-anna.sh
+++ b/dockerfiles/start-anna.sh
@@ -39,7 +39,7 @@ mkdir -p conf
 # determine separate private and public IP addresses. Otherwise, we use the
 # same one for both.
 IS_EC2=`curl -s http://169.254.169.254`
-PRIVATE_IP=`ifconfig eth0 | grep 'inet addr:' | grep -v '127.0.0.1' | cut -d: -f2 | awk '{ print $1 }'`
+PRIVATE_IP=`ifconfig eth0 | grep 'inet' | grep -v inet6 | sed -e 's/^[ \t]*//' | cut -d' ' -f2`
 if [[ ! -z "$IS_EC2" ]]; then
   PUBLIC_IP=`curl http://169.254.169.254/latest/meta-data/public-ipv4`
 else


### PR DESCRIPTION
The latest version of the Hydro base images use Ubuntu 18, which has a different output for `ifconfig`. This PR changes the way we look for the pod's IP address at start time for Ubuntu 18.